### PR TITLE
remove permissions for organization managers

### DIFF
--- a/src/plugin/cursus/Security/Voter/CourseVoter.php
+++ b/src/plugin/cursus/Security/Voter/CourseVoter.php
@@ -50,7 +50,7 @@ class CourseVoter extends AbstractVoter
             case self::EDIT: // admin of organization | EDIT right on tool
             case self::PATCH:
             case self::DELETE:
-                if ($this->isGranted('EDIT', $trainingsTool) || $this->isOrganizationManager($token, $object)) {
+                if ($this->isGranted('EDIT', $trainingsTool)) {
                     return VoterInterface::ACCESS_GRANTED;
                 }
 
@@ -65,7 +65,7 @@ class CourseVoter extends AbstractVoter
                 return VoterInterface::ACCESS_DENIED;
 
             case self::REGISTER:
-                if ($this->isGranted('REGISTER', $trainingsTool) || $this->isOrganizationManager($token, $object)) {
+                if ($this->isGranted('REGISTER', $trainingsTool)) {
                     return VoterInterface::ACCESS_GRANTED;
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed issues | comma-separated list of issues fixed by the PR, if any

This PR remove the default behavior of Claroline who allow edit & create courses, sessions, events if a organization manager is in the same course organization


